### PR TITLE
feat(solution-templates): Add NuGet/ProjectReference switch to ploch-app template

### DIFF
--- a/solution-templates/README.md
+++ b/solution-templates/README.md
@@ -63,7 +63,8 @@ You can also override the sibling root or the reference style per build without 
 
 ```bash
 dotnet build -p:PlochSiblingsRoot=<absolute-path-with-trailing-slash>
-dotnet build -p:UsePlochProjectReferences=true|false
+dotnet build -p:UsePlochProjectReferences=true    # sibling source projects
+dotnet build -p:UsePlochProjectReferences=false   # NuGet packages
 ```
 
 Notes on the reference style:
@@ -73,7 +74,7 @@ Notes on the reference style:
   repo can flip between sibling sources and NuGet packages at any time.
 - `Ploch.CommandLine.Spectre` is not yet published as a NuGet package, so the ConsoleApp project
   references the `ploch-commandline` sibling clone in **both** modes.
-- The SqLite and SqlServer `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection packages
+- The SQLite and SQL Server `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection packages
   share namespaces — a project may reference only one of them at a time.
 
 ### Verify a generated app

--- a/solution-templates/README.md
+++ b/solution-templates/README.md
@@ -56,13 +56,25 @@ names are intentionally fixed.
 |-----------|---------|---------|
 | `-n, --name` | `Ploch.App` | Project/solution/namespace name. |
 | `--siblingsRoot` | `..\` | Relative path (trailing `\`) from the repo root to the parent folder holding the `ploch-*` sibling repos. Override if your clone layout differs. |
+| `--referenceStyle` | `project` | How the generated repo references the Ploch libraries by default: `project` (relative ProjectReferences to sibling clones) or `nuget` (PackageReferences from the MrPloch GitHub Packages feed — requires `MRPLOCH_GITHUB_PACKAGES_TOKEN`). Stamps the default of the `UsePlochProjectReferences` MSBuild property. |
 | `--skipRestore` | `false` | Skip the automatic `dotnet restore` after creation. |
 
-You can also override the sibling root per build without re-templating:
+You can also override the sibling root or the reference style per build without re-templating:
 
 ```bash
 dotnet build -p:PlochSiblingsRoot=<absolute-path-with-trailing-slash>
+dotnet build -p:UsePlochProjectReferences=true|false
 ```
+
+Notes on the reference style:
+
+- Both styles are always present in the generated `.csproj` files, gated by
+  `$(UsePlochProjectReferences)` — `--referenceStyle` only chooses the default, so a generated
+  repo can flip between sibling sources and NuGet packages at any time.
+- `Ploch.CommandLine.Spectre` is not yet published as a NuGet package, so the ConsoleApp project
+  references the `ploch-commandline` sibling clone in **both** modes.
+- The SqLite and SqlServer `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection packages
+  share namespaces — a project may reference only one of them at a time.
 
 ### Verify a generated app
 

--- a/solution-templates/ploch-app/.cursorrules
+++ b/solution-templates/ploch-app/.cursorrules
@@ -4,9 +4,11 @@ MrPloch layered console app (Model → Data → ConsoleApp) on the Ploch.Data ge
 repository / Unit of Work stack and the Ploch.CommandLine.Spectre console host.
 See CLAUDE.md for the canonical, full guidance.
 
-- MrPloch libraries are relative source-project references anchored to `$(PlochSiblingsRoot)`.
-  Clone ploch-common, ploch-data, ploch-commandline and mrploch-development as siblings, or
-  override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`.
+- MrPloch libraries are either relative source-project references anchored to `$(PlochSiblingsRoot)`
+  (clone ploch-common, ploch-data, ploch-commandline and mrploch-development as siblings, or
+  override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`) or NuGet packages from the MrPloch
+  GitHub Packages feed — switch with `-p:UsePlochProjectReferences=true|false`.
+  Ploch.CommandLine.Spectre is not yet published, so it is a sibling source reference in both modes.
 - Entities (src/Model) implement Ploch.Data.Model interfaces — no ad-hoc Id/Name/Title.
 - One internal IEntityTypeConfiguration<T> per entity in src/Data/Configurations; set OnDelete explicitly.
 - Inject the narrowest repository interface; use IUnitOfWork for multi-entity transactions.

--- a/solution-templates/ploch-app/.github/copilot-instructions.md
+++ b/solution-templates/ploch-app/.github/copilot-instructions.md
@@ -14,8 +14,10 @@ root for the canonical agent guidance.
 
 ## Conventions
 
-- MrPloch libraries are referenced as relative source projects anchored to `$(PlochSiblingsRoot)`;
-  the MrPloch repos must be cloned as siblings.
+- MrPloch libraries are referenced either as relative source projects anchored to
+  `$(PlochSiblingsRoot)` (MrPloch repos cloned as siblings) or as NuGet packages from the MrPloch
+  GitHub Packages feed — switch with `-p:UsePlochProjectReferences=true|false`.
+  `Ploch.CommandLine.Spectre` is not yet published, so it stays a sibling source reference in both modes.
 - Entities implement `Ploch.Data.Model` interfaces; configurations are `internal`; set `OnDelete` explicitly.
 - Inject the narrowest repository interface; use `IUnitOfWork` for multi-entity transactions.
 - Tests use xUnit v3, FluentAssertions and AutoFixture.

--- a/solution-templates/ploch-app/.template.config/template.json
+++ b/solution-templates/ploch-app/.template.config/template.json
@@ -26,6 +26,41 @@
       "datatype": "bool",
       "description": "Skip the automatic 'dotnet restore' run after the project is created.",
       "defaultValue": "false"
+    },
+    "referenceStyle": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "How the generated repository references the Ploch libraries by default. Either style can still be flipped at build time with -p:UsePlochProjectReferences=true|false.",
+      "defaultValue": "project",
+      "choices": [
+        {
+          "choice": "project",
+          "description": "Relative ProjectReferences to the side-by-side ploch-* sibling repository clones (local cross-repo development)."
+        },
+        {
+          "choice": "nuget",
+          "description": "PackageReferences restored from the MrPloch GitHub Packages feed (requires the MRPLOCH_GITHUB_PACKAGES_TOKEN environment variable). Note: Ploch.CommandLine.Spectre is not yet published, so the ConsoleApp project always references the ploch-commandline sibling clone."
+        }
+      ]
+    },
+    "usePlochProjectReferences": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "__PLOCH_USE_PROJECT_REFERENCES__",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(referenceStyle == 'nuget')",
+            "value": "false"
+          },
+          {
+            "condition": "",
+            "value": "true"
+          }
+        ]
+      }
     }
   },
   "sources": [

--- a/solution-templates/ploch-app/AGENTS.md
+++ b/solution-templates/ploch-app/AGENTS.md
@@ -9,9 +9,12 @@ command reference — it is the canonical agent guide for this repository.
 
 ## Quick facts
 
-- MrPloch libraries are referenced as **relative source projects** anchored to
-  `$(PlochSiblingsRoot)`; clone `ploch-common`, `ploch-data`, `ploch-commandline` and
-  `mrploch-development` as siblings, or override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`.
+- MrPloch libraries are referenced either as **relative source projects** anchored to
+  `$(PlochSiblingsRoot)` (clone `ploch-common`, `ploch-data`, `ploch-commandline` and
+  `mrploch-development` as siblings, or override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`)
+  or as **NuGet packages** from the MrPloch GitHub Packages feed — switch with
+  `-p:UsePlochProjectReferences=true|false` (default set in `Directory.Build.props`).
+  `Ploch.CommandLine.Spectre` is not yet published, so it is a sibling source reference in both modes.
 - Build: `dotnet build Ploch.App.slnx` · Test: `dotnet test Ploch.App.slnx` ·
   Run: `dotnet run --project src/ConsoleApp -- demo`.
 - EF Core migrations live in `src/Data.SQLite` / `src/Data.SqlServer` (SQLite is the default).

--- a/solution-templates/ploch-app/CLAUDE.md
+++ b/solution-templates/ploch-app/CLAUDE.md
@@ -21,11 +21,23 @@ It is built on the `Ploch.Data` generic repository / Unit of Work stack and the
 
 ## Cross-repository references
 
-This repo references the MrPloch libraries as **relative source-project references**, anchored to
-`$(PlochSiblingsRoot)` (defined in `Directory.Build.props`, default `$(MSBuildThisFileDirectory)..\`).
-All MrPloch repos (`ploch-common`, `ploch-data`, `ploch-commandline`, `mrploch-development`) must be
-cloned as **siblings** under the same parent folder. Override with
-`-p:PlochSiblingsRoot=<path-with-trailing-slash>` if your layout differs.
+This repo references the MrPloch libraries either as **relative source-project references** or as
+**NuGet packages** from the MrPloch GitHub Packages feed, controlled by the
+`UsePlochProjectReferences` MSBuild property (default set in `Directory.Build.props` by the
+template's `--referenceStyle` parameter; flip per build with
+`-p:UsePlochProjectReferences=true|false`).
+
+- ProjectReference mode (`true`): all MrPloch repos (`ploch-common`, `ploch-data`,
+  `ploch-commandline`, `mrploch-development`) must be cloned as **siblings** under the same
+  parent folder, anchored to `$(PlochSiblingsRoot)` (default `$(MSBuildThisFileDirectory)..\`;
+  override with `-p:PlochSiblingsRoot=<path-with-trailing-slash>`).
+- NuGet mode (`false`): `Ploch.*` packages restore from the GitHub feed (`NuGet.Config`;
+  requires `MRPLOCH_GITHUB_PACKAGES_TOKEN`); versions pinned via `PlochPackagesVersion` in
+  `Directory.Packages.props`. Exception: `Ploch.CommandLine.Spectre` is not yet published, so
+  the ConsoleApp always uses the `ploch-commandline` sibling source — which transitively needs
+  the `ploch-common` sibling too. Only the `ploch-data` clone becomes optional in NuGet mode.
+- The SqLite/SqlServer `Ploch.Data.GenericRepository.EFCore.*` DI packages share namespaces —
+  reference only one per project.
 
 Shared package versions and analyzers are imported from `mrploch-development/dependencies/*.props`
 in `Directory.Packages.props` (Central Package Management).

--- a/solution-templates/ploch-app/CLAUDE.md
+++ b/solution-templates/ploch-app/CLAUDE.md
@@ -36,7 +36,7 @@ template's `--referenceStyle` parameter; flip per build with
   `Directory.Packages.props`. Exception: `Ploch.CommandLine.Spectre` is not yet published, so
   the ConsoleApp always uses the `ploch-commandline` sibling source — which transitively needs
   the `ploch-common` sibling too. Only the `ploch-data` clone becomes optional in NuGet mode.
-- The SqLite/SqlServer `Ploch.Data.GenericRepository.EFCore.*` DI packages share namespaces —
+- The SQLite/SQL Server `Ploch.Data.GenericRepository.EFCore.*` DI packages share namespaces —
   reference only one per project.
 
 Shared package versions and analyzers are imported from `mrploch-development/dependencies/*.props`

--- a/solution-templates/ploch-app/Directory.Build.props
+++ b/solution-templates/ploch-app/Directory.Build.props
@@ -8,6 +8,19 @@
             if your clone layout differs.
         -->
         <PlochSiblingsRoot Condition="'$(PlochSiblingsRoot)' == ''">$(MSBuildThisFileDirectory)__PLOCH_SIBLINGS_ROOT__</PlochSiblingsRoot>
+        <!--
+            Reference style for the Ploch libraries (ploch-common / ploch-data / ploch-commandline):
+              true  - relative ProjectReferences into the side-by-side sibling repository clones
+                      (local cross-repo development; the default when the template was generated
+                      with referenceStyle=project).
+              false - PackageReferences restored from the MrPloch GitHub Packages feed (see
+                      NuGet.Config; requires the MRPLOCH_GITHUB_PACKAGES_TOKEN environment variable).
+            The default below was stamped by the 'referenceStyle' template parameter; either mode
+            can be selected per build with -p:UsePlochProjectReferences=true|false.
+            Exception: Ploch.CommandLine.Spectre is not yet published as a NuGet package, so the
+            ConsoleApp project references the ploch-commandline sibling clone in both modes.
+        -->
+        <UsePlochProjectReferences Condition="'$(UsePlochProjectReferences)' == ''">__PLOCH_USE_PROJECT_REFERENCES__</UsePlochProjectReferences>
     </PropertyGroup>
 
     <PropertyGroup Label="Org">

--- a/solution-templates/ploch-app/Directory.Packages.props
+++ b/solution-templates/ploch-app/Directory.Packages.props
@@ -15,4 +15,34 @@
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
     </ItemGroup>
+
+    <!--
+        Versions for the Ploch library packages, used when building with
+        UsePlochProjectReferences=false (NuGet mode — see Directory.Build.props).
+        These packages are served by the MrPloch GitHub Packages feed (see NuGet.Config);
+        3.1.14-prerelease is the newest version published for every package below.
+        The shared mrploch-development/dependencies/Ploch.Packages.props is intentionally
+        not imported here: it pins 3.0.0, which is not available on either feed.
+        Unused in ProjectReference mode (PackageVersion entries without a matching
+        PackageReference are inert under Central Package Management).
+    -->
+    <PropertyGroup Label="Ploch package version">
+        <PlochPackagesVersion>3.1.14-prerelease</PlochPackagesVersion>
+    </PropertyGroup>
+    <ItemGroup Label="Ploch libraries (NuGet mode)">
+        <PackageVersion Include="Ploch.Data.Model" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.EFCore" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.EFCore.SqLite" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.EFCore.SqlServer" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.GenericRepository.EFCore" Version="$(PlochPackagesVersion)" />
+        <!--
+            The two DependencyInjection provider packages share namespaces and method
+            signatures — reference only ONE of them in a given project (the ConsoleApp
+            uses the SqLite one; the SqlServer version is listed for repos that switch
+            their default provider).
+        -->
+        <PackageVersion Include="Ploch.Data.GenericRepository.EFCore.SqLite" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.GenericRepository.EFCore.SqlServer" Version="$(PlochPackagesVersion)" />
+        <PackageVersion Include="Ploch.Data.GenericRepository.EFCore.IntegrationTesting" Version="$(PlochPackagesVersion)" />
+    </ItemGroup>
 </Project>

--- a/solution-templates/ploch-app/GEMINI.md
+++ b/solution-templates/ploch-app/GEMINI.md
@@ -9,9 +9,12 @@ command reference — it is the canonical agent guide for this repository.
 
 ## Quick facts
 
-- MrPloch libraries are referenced as **relative source projects** anchored to
-  `$(PlochSiblingsRoot)`; clone `ploch-common`, `ploch-data`, `ploch-commandline` and
-  `mrploch-development` as siblings, or override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`.
+- MrPloch libraries are referenced either as **relative source projects** anchored to
+  `$(PlochSiblingsRoot)` (clone `ploch-common`, `ploch-data`, `ploch-commandline` and
+  `mrploch-development` as siblings, or override `-p:PlochSiblingsRoot=<path-with-trailing-slash>`)
+  or as **NuGet packages** from the MrPloch GitHub Packages feed — switch with
+  `-p:UsePlochProjectReferences=true|false` (default set in `Directory.Build.props`).
+  `Ploch.CommandLine.Spectre` is not yet published, so it is a sibling source reference in both modes.
 - Build: `dotnet build Ploch.App.slnx` · Test: `dotnet test Ploch.App.slnx` ·
   Run: `dotnet run --project src/ConsoleApp -- demo`.
 - EF Core migrations live in `src/Data.SQLite` / `src/Data.SqlServer` (SQLite is the default).

--- a/solution-templates/ploch-app/README.md
+++ b/solution-templates/ploch-app/README.md
@@ -20,8 +20,26 @@ tests/
 
 ## Prerequisites
 
-This repository references the MrPloch libraries as **relative source-project references**,
-so the following repositories must be cloned **side by side** under the same parent folder:
+This repository can reference the MrPloch libraries in two ways, controlled by the
+`UsePlochProjectReferences` MSBuild property (its default was chosen by the template's
+`--referenceStyle` parameter — see `Directory.Build.props`):
+
+- **ProjectReference mode** (`UsePlochProjectReferences=true`) — relative source-project
+  references into side-by-side sibling clones. Use this for local cross-repo development.
+- **NuGet mode** (`UsePlochProjectReferences=false`) — `Ploch.*` packages restored from the
+  MrPloch GitHub Packages feed (see `NuGet.Config`; requires the
+  `MRPLOCH_GITHUB_PACKAGES_TOKEN` environment variable). Package versions are pinned in
+  `Directory.Packages.props` (`PlochPackagesVersion`).
+
+Either mode can be selected per build without editing any file:
+
+```bash
+dotnet build -p:UsePlochProjectReferences=true    # sibling source projects
+dotnet build -p:UsePlochProjectReferences=false   # NuGet packages
+```
+
+In ProjectReference mode the following repositories must be cloned **side by side** under the
+same parent folder:
 
 ```text
 <parent>/
@@ -32,11 +50,21 @@ so the following repositories must be cloned **side by side** under the same par
   Ploch.App/          <- this repository
 ```
 
+In NuGet mode the `ploch-data` clone is no longer needed, but three siblings are still required:
+`mrploch-development` (shared package-version props), `ploch-commandline` (`Ploch.CommandLine.Spectre`
+is not yet published as a NuGet package, so the ConsoleApp project references its source in **both**
+modes), and `ploch-common` (referenced transitively by `Ploch.CommandLine.Spectre`'s own source
+projects).
+
 If your clone layout differs, override the sibling root at build time:
 
 ```bash
 dotnet build -p:PlochSiblingsRoot=<absolute-path-to-parent-with-trailing-slash>
 ```
+
+> **Note:** the SqLite and SqlServer `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection
+> packages share namespaces and method signatures — a project may reference only **one** of them
+> at a time (the ConsoleApp uses the SqLite one).
 
 ## Build & test
 

--- a/solution-templates/ploch-app/README.md
+++ b/solution-templates/ploch-app/README.md
@@ -62,9 +62,9 @@ If your clone layout differs, override the sibling root at build time:
 dotnet build -p:PlochSiblingsRoot=<absolute-path-to-parent-with-trailing-slash>
 ```
 
-> **Note:** the SqLite and SqlServer `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection
+> **Note:** the SQLite and SQL Server `Ploch.Data.GenericRepository.EFCore.*` DependencyInjection
 > packages share namespaces and method signatures — a project may reference only **one** of them
-> at a time (the ConsoleApp uses the SqLite one).
+> at a time (the ConsoleApp uses the SQLite one).
 
 ## Build & test
 

--- a/solution-templates/ploch-app/src/ConsoleApp/Ploch.App.ConsoleApp.csproj
+++ b/solution-templates/ploch-app/src/ConsoleApp/Ploch.App.ConsoleApp.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
     <!--
-        The SqLite and SqlServer DependencyInjection packages/projects share namespaces and
-        method signatures — reference only ONE of them (this app uses the SqLite one).
+        The SQLite and SQL Server DependencyInjection packages/projects share namespaces and
+        method signatures — reference only ONE of them (this app uses the SQLite one).
     -->
     <ItemGroup Label="Ploch sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.GenericRepository\Data.GenericRepository.EFCore.SqLite\Ploch.Data.GenericRepository.EFCore.SqLite.csproj" />

--- a/solution-templates/ploch-app/src/ConsoleApp/Ploch.App.ConsoleApp.csproj
+++ b/solution-templates/ploch-app/src/ConsoleApp/Ploch.App.ConsoleApp.csproj
@@ -3,8 +3,23 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
-    <ItemGroup Label="Ploch sibling libraries">
+    <!--
+        The SqLite and SqlServer DependencyInjection packages/projects share namespaces and
+        method signatures — reference only ONE of them (this app uses the SqLite one).
+    -->
+    <ItemGroup Label="Ploch sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.GenericRepository\Data.GenericRepository.EFCore.SqLite\Ploch.Data.GenericRepository.EFCore.SqLite.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch libraries (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.GenericRepository.EFCore.SqLite" />
+    </ItemGroup>
+    <!--
+        Ploch.CommandLine.Spectre is not yet published as a NuGet package, so it is a sibling
+        ProjectReference in BOTH reference modes — the ploch-commandline repo must be cloned
+        beside this one even when building with UsePlochProjectReferences=false.
+        Tracked by https://github.com/mrploch/ploch-commandline/issues/7.
+    -->
+    <ItemGroup Label="Ploch.CommandLine (source in both modes)">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-commandline\src\Spectre\CommandLine.Spectre\Ploch.CommandLine.Spectre.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/solution-templates/ploch-app/src/Data.SQLite/Ploch.App.Data.SQLite.csproj
+++ b/solution-templates/ploch-app/src/Data.SQLite/Ploch.App.Data.SQLite.csproj
@@ -2,9 +2,13 @@
     <PropertyGroup>
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
-    <ItemGroup Label="Ploch.Data sibling libraries">
+    <ItemGroup Label="Ploch.Data sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.EFCore.SqLite\Ploch.Data.EFCore.SqLite.csproj" />
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.EFCore\Ploch.Data.EFCore.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch.Data libraries (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.EFCore.SqLite" />
+        <PackageReference Include="Ploch.Data.EFCore" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Data\Ploch.App.Data.csproj" />

--- a/solution-templates/ploch-app/src/Data.SqlServer/Ploch.App.Data.SqlServer.csproj
+++ b/solution-templates/ploch-app/src/Data.SqlServer/Ploch.App.Data.SqlServer.csproj
@@ -2,9 +2,13 @@
     <PropertyGroup>
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
-    <ItemGroup Label="Ploch.Data sibling libraries">
+    <ItemGroup Label="Ploch.Data sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.EFCore.SqlServer\Ploch.Data.EFCore.SqlServer.csproj" />
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.EFCore\Ploch.Data.EFCore.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch.Data libraries (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.EFCore.SqlServer" />
+        <PackageReference Include="Ploch.Data.EFCore" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Data\Ploch.App.Data.csproj" />

--- a/solution-templates/ploch-app/src/Data/Ploch.App.Data.csproj
+++ b/solution-templates/ploch-app/src/Data/Ploch.App.Data.csproj
@@ -2,9 +2,13 @@
     <PropertyGroup>
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
-    <ItemGroup Label="Ploch.Data sibling libraries">
+    <ItemGroup Label="Ploch.Data sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.EFCore\Ploch.Data.EFCore.csproj" />
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.GenericRepository\Data.GenericRepository.EFCore\Ploch.Data.GenericRepository.EFCore.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch.Data libraries (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.EFCore" />
+        <PackageReference Include="Ploch.Data.GenericRepository.EFCore" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Model\Ploch.App.Model.csproj" />

--- a/solution-templates/ploch-app/src/Model/Ploch.App.Model.csproj
+++ b/solution-templates/ploch-app/src/Model/Ploch.App.Model.csproj
@@ -2,7 +2,10 @@
     <PropertyGroup>
         <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Label="Ploch sibling libraries (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.Model\Ploch.Data.Model.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch libraries (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.Model" />
     </ItemGroup>
 </Project>

--- a/solution-templates/ploch-app/tests/IntegrationTests/Ploch.App.IntegrationTests.csproj
+++ b/solution-templates/ploch-app/tests/IntegrationTests/Ploch.App.IntegrationTests.csproj
@@ -16,8 +16,11 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
-    <ItemGroup Label="Ploch.Data integration-testing harness">
+    <ItemGroup Label="Ploch.Data integration-testing harness (source)" Condition="'$(UsePlochProjectReferences)' == 'true'">
         <ProjectReference Include="$(PlochSiblingsRoot)ploch-data\src\Data.GenericRepository\Data.GenericRepository.EFCore.IntegrationTesting\Ploch.Data.GenericRepository.EFCore.IntegrationTesting.csproj" />
+    </ItemGroup>
+    <ItemGroup Label="Ploch.Data integration-testing harness (NuGet)" Condition="'$(UsePlochProjectReferences)' != 'true'">
+        <PackageReference Include="Ploch.Data.GenericRepository.EFCore.IntegrationTesting" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Data\Ploch.App.Data.csproj" />


### PR DESCRIPTION
## **User description**
## Summary

Adds the **NuGet ↔ ProjectReference switch** to the `ploch-app` `dotnet new` solution template — Phase 1 of the roadmap recorded in #9. Generated repositories can now reference the Ploch libraries (`ploch-common` / `ploch-data` / `ploch-commandline`) either as relative ProjectReferences to side-by-side sibling clones or as NuGet packages restored from the MrPloch GitHub Packages feed, and can flip between the two at any time without re-generating.

Closes #12.

## Changes

- **`.template.config/template.json`** — new `referenceStyle` choice parameter (`project` default | `nuget`) plus a generated `switch` symbol that stamps `true`/`false` into the `__PLOCH_USE_PROJECT_REFERENCES__` token.
- **`Directory.Build.props`** — new `UsePlochProjectReferences` MSBuild property whose default is the stamped token; either mode can be selected per build with `-p:UsePlochProjectReferences=true|false`.
- **All six `.csproj` files** (Model, Data, Data.SQLite, Data.SqlServer, ConsoleApp, IntegrationTests) — paired ItemGroups: the existing curated ProjectReference set gated on `== 'true'`, a matching PackageReference set gated on `!= 'true'`. Both sets are always emitted, so the choice is purely a build-time property.
- **`Directory.Packages.props`** — `PlochPackagesVersion` pinned to `3.1.14-prerelease` with `PackageVersion` entries for the eight `Ploch.Data.*` packages.
- **Docs** — `solution-templates/README.md` (parameters table + reference-style notes), template `README.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`.

## Design Decisions

- **Both reference styles always present, gated by an MSBuild property** (rather than `dotnet new` conditional content): the template symbol only stamps the property default, so every generated repo gets the build-time toggle for free and the template output is identical modulo one token. Modelled on `ploch-data`'s `UsePlochProjectReferences` mechanism, but with per-project curated reference sets instead of a global remove/add overlay.
- **`PlochPackagesVersion` = `3.1.14-prerelease`**: the only version that exists for *every* required package. The shared `dependencies/Ploch.Packages.props` pins `3.0.0`, which exists on **no** feed (nuget.org has `3.0.1`, and `Ploch.Data.GenericRepository.EFCore.SqLite` has no stable release anywhere), so it is deliberately not imported — explained in a comment in the file.
- **`Ploch.CommandLine.Spectre` stays a sibling ProjectReference in both modes**: it has never been published to any feed (ploch-commandline CI has never run) — tracked by mrploch/ploch-commandline#7. Consequently NuGet mode still requires the `ploch-commandline` and (transitively, via its source projects) `ploch-common` clones; only `ploch-data` becomes optional. Documented in the template README/CLAUDE.md.
- **DI provider exclusivity**: `Ploch.Data.GenericRepository.EFCore.SqLite` and `.SqlServer` share namespaces/method signatures, so only one may be referenced per project — the ConsoleApp uses the SqLite one; comments in the csproj and `Directory.Packages.props` call this out.

## Testing

- `project` mode (default): generated app builds with **zero warnings from generated code**, **9/9 integration tests pass**.
- `nuget` mode (`--referenceStyle nuget`): stamped default verified, restore pulls `3.1.14-prerelease` from the GitHub Packages feed, builds clean, **9/9 tests pass**, and the Spectre `demo` command runs end-to-end.
- Build-time flip: a `project`-mode repo built with `-p:UsePlochProjectReferences=false` restores/builds/passes 9/9 tests.
- Final smoke test re-run after review fixes (install → generate → build → 9/9 tests).
- Code-review pass performed; its one finding (README understated the sibling clones needed in NuGet mode) is fixed in this PR.

## Related

- Closes #12
- Roadmap origin: #9 (Phase 1)
- Blocks full NuGet mode: mrploch/ploch-commandline#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new `--referenceStyle` parameter to the solution template to toggle between local project references and NuGet package references for Ploch libraries.</li>
<li>Updated MSBuild configuration to support switching between sibling source references and NuGet packages via the `UsePlochProjectReferences` property.</li>
<li>Updated documentation in README, .cursorrules, and copilot-instructions to reflect the new reference style options.</li>
<li>Configured the template to allow flipping reference styles at build time, while noting that `Ploch.CommandLine.Spectre` remains a sibling reference due to its current availability status.</li>
</ul></div>


___

## **CodeAnt-AI Description**
Let generated Ploch apps switch between sibling source projects and NuGet packages

### What Changed
- Added a `--referenceStyle` template option that defaults generated apps to either local sibling-project references or Ploch packages from the GitHub Packages feed.
- Generated apps can switch reference styles for any build without being regenerated.
- Added package versions and package references for the model, data, database-provider, repository, and integration-testing libraries.
- The command-line library remains a sibling source reference in both modes because its NuGet package is not yet published.
- Updated setup and usage guidance, including package authentication and the remaining sibling repositories required in NuGet mode.

### Impact
`✅ NuGet-based builds without a local ploch-data clone`
`✅ Faster switching between local development and package-based builds`
`✅ Clearer setup requirements for generated repositories`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

## Summary by Sourcery

Add a configurable project-vs-NuGet reference style to the ploch-app solution template, with centralized version pinning and documentation updates so generated apps can switch dependency modes per build without re-templating.

New Features:
- Add a referenceStyle template parameter to let generated ploch-app solutions default to either sibling ProjectReferences or NuGet PackageReferences for Ploch libraries.
- Enable build-time switching between project and NuGet reference styles via the UsePlochProjectReferences MSBuild property without re-generating the template.

Enhancements:
- Introduce curated dual project/package reference item groups across ploch-app projects so both dependency styles are always available.
- Pin Ploch package versions centrally in Directory.Packages.props to support NuGet-based builds from the GitHub Packages feed.
- Clarify dependency constraints around EF Core SqLite/SqlServer DI packages and the always-sibling Ploch.CommandLine.Spectre source project.

Documentation:
- Update solution-templates and ploch-app README files and agent/copilot guides to document the new reference-style options, required sibling repos, and NuGet feed setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a template option to choose between sibling project references and NuGet package references.
  * Added build-time switching between reference modes without regenerating the application.
  * Added centralized package version management for NuGet-based builds.
  * Preserved required source references for unpublished command-line components.

* **Documentation**
  * Expanded setup guidance, build examples, repository layout requirements, authentication, and database provider notes.
  * Updated contributor and coding-assistant guidance to describe both supported reference modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->